### PR TITLE
feat: make profile page show top tracks

### DIFF
--- a/app/profile/[username]/page.tsx
+++ b/app/profile/[username]/page.tsx
@@ -49,7 +49,6 @@ const Profile = async ({ params }: { params: { username: string } }) => {
       )}
       <div className="divider" />
       <TopItems artists={data.topArtists} tracks={data.topTracks} />
-      {/* <pre>{JSON.stringify(data, null, 2)}</pre> */}
     </>
   );
 };

--- a/app/profile/[username]/page.tsx
+++ b/app/profile/[username]/page.tsx
@@ -7,10 +7,10 @@ import isUserFollowing from "@/lib/followers/isUserFollowing";
 import { formatNumber } from "@/lib/formatters";
 import { getCurrentUser, getUserByUsername } from "@/lib/getUser";
 
-const Profile = async ({ params }: { params: { username?: string[] } }) => {
+const Profile = async ({ params }: { params: { username: string } }) => {
   const currentUser = await getCurrentUser();
   const currentUsername = currentUser.username;
-  const username = params.username?.[0] ?? currentUsername;
+  const { username } = params;
 
   const profile = await getUserByUsername(username);
   if (!profile) {
@@ -18,7 +18,7 @@ const Profile = async ({ params }: { params: { username?: string[] } }) => {
   }
 
   const isFollowed = await isUserFollowing(profile.id);
-  const showFollowButton = username !== currentUsername && params.username?.[0];
+  const showFollowButton = username !== currentUsername;
 
   return (
     <div>

--- a/app/profile/[username]/page.tsx
+++ b/app/profile/[username]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import FollowButton from "@/components/profile/FollowButton";
 import ProfileHead from "@/components/profile/ProfileHead";
+import TopItems from "@/components/profile/TopItems";
 import { profilesCol } from "@/lib/firestore";
 import isUserFollowing from "@/lib/followers/isUserFollowing";
 import { getCurrentUser, getUserByUsername } from "@/lib/getUser";
@@ -38,7 +39,8 @@ const Profile = async ({ params }: { params: { username: string } }) => {
         <FollowButton isFollowing={isFollowed} username={username} />
       )}
       <div className="divider" />
-      <pre>{JSON.stringify(data, null, 2)}</pre>
+      <TopItems artists={data.topArtists} tracks={data.topTracks} />
+      {/* <pre>{JSON.stringify(data, null, 2)}</pre> */}
     </>
   );
 };

--- a/app/profile/[username]/page.tsx
+++ b/app/profile/[username]/page.tsx
@@ -1,9 +1,20 @@
+import { doc, getDoc } from "firebase/firestore";
 import { notFound } from "next/navigation";
 
 import FollowButton from "@/components/profile/FollowButton";
 import ProfileHead from "@/components/profile/ProfileHead";
+import { profilesCol } from "@/lib/firestore";
 import isUserFollowing from "@/lib/followers/isUserFollowing";
 import { getCurrentUser, getUserByUsername } from "@/lib/getUser";
+
+const getData = async (id: string) => {
+  const profileDoc = await getDoc(doc(profilesCol, id));
+  if (!profileDoc.exists()) {
+    notFound();
+  }
+
+  return profileDoc.data();
+};
 
 const Profile = async ({ params }: { params: { username: string } }) => {
   const currentUser = await getCurrentUser();
@@ -18,6 +29,8 @@ const Profile = async ({ params }: { params: { username: string } }) => {
   const isFollowed = await isUserFollowing(profile.id);
   const showFollowButton = username !== currentUsername;
 
+  const data = await getData(profile.id);
+
   return (
     <>
       <ProfileHead user={profile} />
@@ -25,6 +38,7 @@ const Profile = async ({ params }: { params: { username: string } }) => {
         <FollowButton isFollowing={isFollowed} username={username} />
       )}
       <div className="divider" />
+      <pre>{JSON.stringify(data, null, 2)}</pre>
     </>
   );
 };

--- a/app/profile/[username]/page.tsx
+++ b/app/profile/[username]/page.tsx
@@ -1,10 +1,8 @@
 import { notFound } from "next/navigation";
 
 import FollowButton from "@/components/profile/FollowButton";
-import PageTitle from "@/components/ui/PageTitle";
-import ProfileImg from "@/components/userProfile/profileImg";
+import ProfileHead from "@/components/profile/ProfileHead";
 import isUserFollowing from "@/lib/followers/isUserFollowing";
-import { formatNumber } from "@/lib/formatters";
 import { getCurrentUser, getUserByUsername } from "@/lib/getUser";
 
 const Profile = async ({ params }: { params: { username: string } }) => {
@@ -21,27 +19,13 @@ const Profile = async ({ params }: { params: { username: string } }) => {
   const showFollowButton = username !== currentUsername;
 
   return (
-    <div>
-      <PageTitle title="Profile" />
-      <div className="flex flex-row items-center pb-4">
-        {/* @ts-expect-error Server Component */}
-        <ProfileImg username={username} isProfilePage />
-        <div className="flex flex-col">
-          <h1 className="normal-case font-bold">
-            {!profile.displayName || username === profile.displayName
-              ? username
-              : `${profile.displayName} — ${username}`}
-          </h1>
-          <h2 className="normal-case">
-            {formatNumber(profile.followers)} followers
-          </h2>
-        </div>
-      </div>
+    <>
+      <ProfileHead user={profile} />
       {showFollowButton && (
         <FollowButton isFollowing={isFollowed} username={username} />
       )}
       <div className="divider" />
-    </div>
+    </>
   );
 };
 

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -1,0 +1,10 @@
+import PageTitle from "@/components/ui/PageTitle";
+
+const Layout = ({ children }: { children: React.ReactNode }) => (
+  <>
+    <PageTitle title="Profile" />
+    {children}
+  </>
+);
+
+export default Layout;

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import Skeleton from "react-loading-skeleton";
+
+const Page = () => {
+  const { data: session, status } = useSession();
+
+  const router = useRouter();
+
+  if (status === "authenticated") {
+    return router.replace(`/profile/${session.user.username}`);
+  }
+
+  return <Skeleton />;
+};
+
+export default Page;

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -11,10 +11,10 @@ const Page = () => {
 
   if (status === "authenticated") {
     router.replace(`/profile/${session.user.username}`);
-    return <Skeleton enableAnimation />;
+    return <Skeleton enableAnimation count={8} />;
   }
 
-  return <Skeleton enableAnimation />;
+  return <Skeleton enableAnimation count={8} />;
 };
 
 export default Page;

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -10,10 +10,11 @@ const Page = () => {
   const router = useRouter();
 
   if (status === "authenticated") {
-    return router.replace(`/profile/${session.user.username}`);
+    router.replace(`/profile/${session.user.username}`);
+    return <Skeleton enableAnimation />;
   }
 
-  return <Skeleton />;
+  return <Skeleton enableAnimation />;
 };
 
 export default Page;

--- a/components/feed/FeedItem.tsx
+++ b/components/feed/FeedItem.tsx
@@ -1,5 +1,5 @@
+import ProfileImage from "@/components/profile/ProfileImage";
 import UsernameLink from "@/components/ui/UsernameLink";
-import ProfileImg from "@/components/userProfile/profileImg";
 
 import DeleteButton from "./DeleteButton";
 import FeedCommentBox from "./FeedCommentBox";
@@ -26,7 +26,7 @@ const FeedItem = ({
       <div className="flex flex-row justify-between items-center">
         <div className="flex flex-row items-center pb-4">
           {/* @ts-expect-error Server Component */}
-          <ProfileImg username={data.username} />
+          <ProfileImage username={data.username} />
           <div>
             {showLink ? (
               <UsernameLink username={data.username} />

--- a/components/feed/FeedItemComment.tsx
+++ b/components/feed/FeedItemComment.tsx
@@ -1,5 +1,5 @@
+import ProfileImage from "@/components/profile/ProfileImage";
 import UsernameLink from "@/components/ui/UsernameLink";
-import ProfileImg from "@/components/userProfile/profileImg";
 
 import DeleteButton from "./DeleteButton";
 
@@ -21,7 +21,7 @@ const FeedItemComment = ({
     <div className="flex flex-row justify-between items-center">
       <div className="flex flex-row items-center pb-4">
         {/* @ts-expect-error Server Component */}
-        <ProfileImg username={commentData.username} />
+        <ProfileImage username={commentData.username} />
         <div>
           {showLink ? (
             <UsernameLink username={commentData.username} />

--- a/components/profile/ProfileHead.tsx
+++ b/components/profile/ProfileHead.tsx
@@ -1,19 +1,19 @@
 import ProfileImg from "@/components/userProfile/profileImg";
 import { formatNumber } from "@/lib/formatters";
 
-import type { User } from "next-auth";
-
-const ProfileHead = ({ user }: { user: User }) => (
+const ProfileHead = ({ user }: { user: SpotifyApi.UserProfileResponse }) => (
   <div className="flex flex-row items-center pb-4">
     {/* @ts-expect-error Server Component */}
     <ProfileImg user={user} isProfilePage />
     <div className="flex flex-col">
       <h1 className="normal-case font-bold">
-        {!user.displayName || user.username === user.displayName
-          ? user.username
-          : `${user.displayName} — ${user.username}`}
+        {!user.display_name || user.id === user.display_name
+          ? user.id
+          : `${user.display_name} — ${user.id}`}
       </h1>
-      <h2 className="normal-case">{formatNumber(user.followers)} followers</h2>
+      <h2 className="normal-case">
+        {formatNumber(user.followers?.total)} followers
+      </h2>
     </div>
   </div>
 );

--- a/components/profile/ProfileHead.tsx
+++ b/components/profile/ProfileHead.tsx
@@ -3,17 +3,19 @@ import { formatNumber } from "@/lib/formatters";
 
 const ProfileHead = ({ user }: { user: SpotifyApi.UserProfileResponse }) => (
   <div className="flex flex-row items-center pb-4">
-    {/* @ts-expect-error Server Component */}
-    <ProfileImg user={user} isProfilePage />
+    <a href={user.uri}>
+      {/* @ts-expect-error Server Component */}
+      <ProfileImg user={user} isProfilePage hideLink />
+    </a>
     <div className="flex flex-col">
-      <h1 className="normal-case font-bold">
+      <h2 className="normal-case font-bold">
         {!user.display_name || user.id === user.display_name
           ? user.id
           : `${user.display_name} — ${user.id}`}
-      </h1>
-      <h2 className="normal-case">
-        {formatNumber(user.followers?.total)} followers
       </h2>
+      <h3 className="normal-case">
+        {formatNumber(user.followers?.total)} followers
+      </h3>
     </div>
   </div>
 );

--- a/components/profile/ProfileHead.tsx
+++ b/components/profile/ProfileHead.tsx
@@ -1,0 +1,21 @@
+import ProfileImg from "@/components/userProfile/profileImg";
+import { formatNumber } from "@/lib/formatters";
+
+import type { User } from "next-auth";
+
+const ProfileHead = ({ user }: { user: User }) => (
+  <div className="flex flex-row items-center pb-4">
+    {/* @ts-expect-error Server Component */}
+    <ProfileImg user={user} isProfilePage />
+    <div className="flex flex-col">
+      <h1 className="normal-case font-bold">
+        {!user.displayName || user.username === user.displayName
+          ? user.username
+          : `${user.displayName} — ${user.username}`}
+      </h1>
+      <h2 className="normal-case">{formatNumber(user.followers)} followers</h2>
+    </div>
+  </div>
+);
+
+export default ProfileHead;

--- a/components/profile/ProfileHead.tsx
+++ b/components/profile/ProfileHead.tsx
@@ -1,11 +1,11 @@
-import ProfileImg from "@/components/userProfile/profileImg";
+import ProfileImage from "@/components/profile/ProfileImage";
 import { formatNumber } from "@/lib/formatters";
 
 const ProfileHead = ({ user }: { user: SpotifyApi.UserProfileResponse }) => (
   <div className="flex flex-row items-center pb-4">
     <a href={user.uri}>
       {/* @ts-expect-error Server Component */}
-      <ProfileImg user={user} isProfilePage hideLink />
+      <ProfileImage user={user} isProfilePage hideLink />
     </a>
     <div className="flex flex-col">
       <h2 className="normal-case font-bold">

--- a/components/profile/ProfileImage.tsx
+++ b/components/profile/ProfileImage.tsx
@@ -8,7 +8,7 @@ const getData = async (username: string) =>
     `https://api.spotify.com/v1/users/${username}`
   );
 
-type ProfileImgProps =
+type ProfileImageProps =
   | {
       username: string;
       user?: never;
@@ -22,12 +22,12 @@ type ProfileImgProps =
       hideLink?: boolean;
     };
 
-const ProfileImg = async ({
+const ProfileImage = async ({
   username,
   user,
   isProfilePage,
   hideLink,
-}: ProfileImgProps) => {
+}: ProfileImageProps) => {
   const profile = username ? await getData(username) : user;
   const img = profile?.images?.[0]?.url;
 
@@ -62,4 +62,4 @@ const ProfileImg = async ({
   );
 };
 
-export default ProfileImg;
+export default ProfileImage;

--- a/components/profile/TopItems/TopArtists.tsx
+++ b/components/profile/TopItems/TopArtists.tsx
@@ -1,0 +1,19 @@
+import Artist from "@/components/music/Artist";
+
+const TopArtists = ({
+  artists,
+}: {
+  artists: SpotifyApi.ArtistObjectFull[];
+}) => (
+  <div>
+    <h2 className="font-black pb-4">Top Artists</h2>
+    <div className="grid grid-cols-3 gap-4 pb-5">
+      {artists.splice(0, 6).map((artist) => (
+        // @ts-expect-error Next 13 handles async components
+        <Artist key={artist.id} artist={artist} />
+      ))}
+    </div>
+  </div>
+);
+
+export default TopArtists;

--- a/components/profile/TopItems/TopTracks.tsx
+++ b/components/profile/TopItems/TopTracks.tsx
@@ -1,0 +1,15 @@
+import Track from "@/components/music/Track";
+
+const TopTracks = ({ tracks }: { tracks: SpotifyApi.TrackObjectFull[] }) => (
+  <div>
+    <h2 className="font-black pb-4">Top Tracks</h2>
+    <div className="grid grid-cols-3 gap-4 pb-5">
+      {tracks.splice(0, 6).map((track) => (
+        // @ts-expect-error Next 13 handles async components
+        <Track key={track.id} track={track} />
+      ))}
+    </div>
+  </div>
+);
+
+export default TopTracks;

--- a/components/profile/TopItems/index.tsx
+++ b/components/profile/TopItems/index.tsx
@@ -1,0 +1,17 @@
+import TopArtists from "./TopArtists";
+import TopTracks from "./TopTracks";
+
+const TopItems = ({
+  artists,
+  tracks,
+}: {
+  artists: SpotifyApi.ArtistObjectFull[];
+  tracks: SpotifyApi.TrackObjectFull[];
+}) => (
+  <div className="grid md:grid-cols-2 gap-4 pb-5">
+    <TopArtists artists={artists} />
+    <TopTracks tracks={tracks} />
+  </div>
+);
+
+export default TopItems;

--- a/components/userProfile/profileImg.tsx
+++ b/components/userProfile/profileImg.tsx
@@ -2,51 +2,33 @@ import Image from "next/image";
 
 import { getUserByUsername } from "@/lib/getUser";
 
+import type { User } from "next-auth";
+
+type ProfileImgProps =
+  | {
+      username: string;
+      user?: never;
+      isProfilePage: boolean;
+    }
+  | {
+      username?: never;
+      user: User;
+      isProfilePage: boolean;
+    };
+
 const ProfileImg = async ({
   username,
+  user,
   isProfilePage,
-}: {
-  username: string | undefined;
-  isProfilePage: boolean | undefined;
-}) => {
-  if (!username) {
-    throw new Error("No username provided");
-  }
-
-  const profile = await getUserByUsername(username);
+}: ProfileImgProps) => {
+  const profile = username ? await getUserByUsername(username) : user;
   const img = profile?.image;
-
-  if (img) {
-    return (
-      <Image
-        src={img}
-        width={300}
-        height={300}
-        style={
-          isProfilePage
-            ? {
-                width: 60,
-                height: 60,
-                borderRadius: 60 / 2,
-                marginRight: 7,
-              }
-            : {
-                width: 30,
-                height: 30,
-                borderRadius: 30 / 2,
-                marginRight: 7,
-              }
-        }
-        alt={`${username}'s profile picture`}
-      />
-    );
-  }
 
   return (
     <Image
-      src="/images/defaults/profileImage.png"
-      width={720}
-      height={720}
+      src={img ?? "/images/defaults/profileImage.png"}
+      width={300}
+      height={300}
       style={
         isProfilePage
           ? {
@@ -62,7 +44,7 @@ const ProfileImg = async ({
               marginRight: 7,
             }
       }
-      alt="default profile picture"
+      alt={`${profile?.username ?? "default"}'s profile picture`}
     />
   );
 };

--- a/components/userProfile/profileImg.tsx
+++ b/components/userProfile/profileImg.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 import getSpotifyData from "@/lib/getSpotifyData";
 
@@ -12,22 +13,25 @@ type ProfileImgProps =
       username: string;
       user?: never;
       isProfilePage: boolean;
+      hideLink?: boolean;
     }
   | {
       username?: never;
       user: SpotifyApi.UserObjectPublic;
       isProfilePage: boolean;
+      hideLink?: boolean;
     };
 
 const ProfileImg = async ({
   username,
   user,
   isProfilePage,
+  hideLink,
 }: ProfileImgProps) => {
   const profile = username ? await getData(username) : user;
   const img = profile?.images?.[0]?.url;
 
-  return (
+  const ImageComponent = (
     <Image
       src={img ?? "/images/defaults/profileImage.png"}
       width={300}
@@ -49,6 +53,12 @@ const ProfileImg = async ({
       }
       alt={`${profile?.id ?? "default"}'s profile picture`}
     />
+  );
+
+  return hideLink || !profile ? (
+    ImageComponent
+  ) : (
+    <Link href={`/profile/${profile.id}`}>{ImageComponent}</Link>
   );
 };
 

--- a/components/userProfile/profileImg.tsx
+++ b/components/userProfile/profileImg.tsx
@@ -1,8 +1,11 @@
 import Image from "next/image";
 
-import { getUserByUsername } from "@/lib/getUser";
+import getSpotifyData from "@/lib/getSpotifyData";
 
-import type { User } from "next-auth";
+const getData = async (username: string) =>
+  getSpotifyData<SpotifyApi.UserProfileResponse>(
+    `https://api.spotify.com/v1/users/${username}`
+  );
 
 type ProfileImgProps =
   | {
@@ -12,7 +15,7 @@ type ProfileImgProps =
     }
   | {
       username?: never;
-      user: User;
+      user: SpotifyApi.UserObjectPublic;
       isProfilePage: boolean;
     };
 
@@ -21,8 +24,8 @@ const ProfileImg = async ({
   user,
   isProfilePage,
 }: ProfileImgProps) => {
-  const profile = username ? await getUserByUsername(username) : user;
-  const img = profile?.image;
+  const profile = username ? await getData(username) : user;
+  const img = profile?.images?.[0]?.url;
 
   return (
     <Image
@@ -44,7 +47,7 @@ const ProfileImg = async ({
               marginRight: 7,
             }
       }
-      alt={`${profile?.username ?? "default"}'s profile picture`}
+      alt={`${profile?.id ?? "default"}'s profile picture`}
     />
   );
 };

--- a/lib/firestore/index.ts
+++ b/lib/firestore/index.ts
@@ -5,6 +5,7 @@ import type {
   FirestoreUser,
   FirestoreFeedItem,
   FirestoreProfile,
+  FirestoreAccount,
 } from "./types";
 import type { DocumentData, CollectionReference } from "firebase/firestore";
 
@@ -43,6 +44,7 @@ const createCollection = <T = DocumentData>(
   ) as CollectionReference<T>;
 
 export const usersCol = createCollection<FirestoreUser>("users");
+export const accountsCol = createCollection<FirestoreAccount>("accounts");
 export const feedCol = createCollection<FirestoreFeedItem>("feed_items");
 
 export const getCommentsCol = (feedId: string) =>

--- a/lib/firestore/types.ts
+++ b/lib/firestore/types.ts
@@ -1,7 +1,9 @@
 import type { Timestamp } from "firebase/firestore";
-import type { User } from "next-auth";
+import type { Account, User } from "next-auth";
 
 export type FirestoreUser = User;
+
+export type FirestoreAccount = Account;
 
 export type FirestoreFeedItem = {
   timestamp: Timestamp;

--- a/lib/followers/isUserFollowing.ts
+++ b/lib/followers/isUserFollowing.ts
@@ -2,7 +2,10 @@ import getSpotifyData from "@/lib/getSpotifyData";
 
 const isUserFollowing = async (username: string) =>
   getSpotifyData<SpotifyApi.UserFollowsUsersOrArtistsResponse>(
-    `https://api.spotify.com/v1/me/following/contains?type=user&ids=${username}`
+    `https://api.spotify.com/v1/me/following/contains?type=user&ids=${username}`,
+    {
+      cache: "no-cache",
+    }
   ).then((response) => response[0]);
 
 export default isUserFollowing;

--- a/lib/followers/toggleFollowing.ts
+++ b/lib/followers/toggleFollowing.ts
@@ -7,6 +7,7 @@ const toggleFollowing = async (username: string, isFollowing: boolean) =>
     `https://api.spotify.com/v1/me/following?type=user&ids=${username}`,
     {
       method: isFollowing ? "DELETE" : "PUT",
+      cache: "no-cache",
     }
   );
 

--- a/lib/getUser.ts
+++ b/lib/getUser.ts
@@ -1,9 +1,41 @@
-import { getDocs } from "firebase/firestore";
+import { getDocs, query, where } from "firebase/firestore";
 import { getServerSession } from "next-auth";
 import "server-only";
 
-import { usersCol } from "@/lib/firestore";
+import { accountsCol } from "@/lib/firestore";
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
+
+/**
+ * Matches a Firestore user ID to a Spotify username.
+ *
+ * @param userId the Firestore user ID to search for
+ * @returns the Spotify username of the user with the given ID, or undefined if no user is found
+ */
+export const getUsernameFromId = async (userId: string) => {
+  const q = query(accountsCol, where("userId", "==", userId));
+
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) {
+    return undefined;
+  }
+  return snapshot.docs[0].data().username;
+};
+
+/**
+ * Matches a Spotify username to a Firestore user ID.
+ *
+ * @param username the Spotify username to search for
+ * @returns the Firestore user ID of the user with the given username, or undefined if no user is found
+ */
+export const getIdFromUsername = async (username: string) => {
+  const q = query(accountsCol, where("providerAccountId", "==", username));
+
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) {
+    return undefined;
+  }
+  return snapshot.docs[0].data().userId;
+};
 
 /**
  * Returns the currently logged in user, according to
@@ -19,38 +51,4 @@ export const getCurrentUser = async () => {
     throw new Error("No session");
   }
   return session.user;
-};
-
-/**
- * Returns the user with the given username from firestore.
- *
- * @param username The username to search for
- * @returns The user with the given username, or undefined if no user is found
- */
-export const getUserByUsername = async (username: string) => {
-  const usersSnapshot = await getDocs(usersCol);
-  const usersData = usersSnapshot.docs.map((doc) => ({
-    ...doc.data(),
-    id: doc.id,
-  }));
-
-  return usersData.find((user) =>
-    user.username.toLowerCase().includes(username.toLowerCase())
-  );
-};
-
-/**
- * Returns the user with the given id from firestore.
- *
- * @param id The id to search for
- * @returns The user with the given id, or undefined if no user is found
- */
-export const getUserById = async (id: string) => {
-  const usersSnapshot = await getDocs(usersCol);
-  const usersData = usersSnapshot.docs.map((doc) => ({
-    ...doc.data(),
-    id: doc.id,
-  }));
-
-  return usersData.find((user) => user.id === id);
 };

--- a/lib/getUser.ts
+++ b/lib/getUser.ts
@@ -29,7 +29,10 @@ export const getCurrentUser = async () => {
  */
 export const getUserByUsername = async (username: string) => {
   const usersSnapshot = await getDocs(usersCol);
-  const usersData = usersSnapshot.docs.map((doc) => doc.data());
+  const usersData = usersSnapshot.docs.map((doc) => ({
+    ...doc.data(),
+    id: doc.id,
+  }));
 
   return usersData.find((user) =>
     user.username.toLowerCase().includes(username.toLowerCase())
@@ -44,7 +47,10 @@ export const getUserByUsername = async (username: string) => {
  */
 export const getUserById = async (id: string) => {
   const usersSnapshot = await getDocs(usersCol);
-  const usersData = usersSnapshot.docs.map((doc) => doc.data());
+  const usersData = usersSnapshot.docs.map((doc) => ({
+    ...doc.data(),
+    id: doc.id,
+  }));
 
   return usersData.find((user) => user.id === id);
 };

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -126,8 +126,6 @@ export const authOptions: NextAuthOptions = {
         username: profile.id,
         uri: profile.uri,
         url: profile.external_urls.spotify,
-        followers: profile.followers?.total ?? 0,
-        image: profile.images?.[0]?.url,
       }),
     }),
   ],

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -26,8 +26,6 @@ declare module "next-auth" {
     username: string;
     uri: string;
     url: string;
-    followers: number;
-    image: string | undefined;
   }
 
   interface Session extends DefaultSession {


### PR DESCRIPTION
- chore: update Next
- feat: simplify profile page logic
- feat: split profile head to separate component
- fix: add firestore ID to users docs return
- feat: get profile data from firestore
- feat: display top artists and tracks on profile page
- feat!: fix username vs ID for profile page fetching
- feat: make profile pictures clickable
- fix: remove unneeded comment
- fix: update loading style

---

# IMPORTANT!

This changes how `getUser` is used, because we shouldn't be storing so much
data in Firestore that changes (e.g. following)
