### PR TITLE
fix: link track in friends to internal page

### DIFF
--- a/components/Sidebar/panels/Friends/FriendItem.tsx
+++ b/components/Sidebar/panels/Friends/FriendItem.tsx
@@ -8,7 +8,7 @@ const FriendItem = ({ track }: { track: SpotifyApi.TrackObjectSimplified }) => (
       <h5 className="text-xs truncate max-w-[112px]">
         <Link
           className="link link-hover link-secondary truncate max-w-[100px]"
-          href={track.external_urls.spotify}
+          href={`/track/${track.id}`}
         >
           {track.name}
         </Link>


### PR DESCRIPTION
- fix: link track in friends to internal page instead of external spotify 